### PR TITLE
DESCRIPTION file updated

### DIFF
--- a/hyperSpec/DESCRIPTION
+++ b/hyperSpec/DESCRIPTION
@@ -6,6 +6,10 @@ Version: 0.98-20170803
 Date: 2017-08-03
 Author: Claudia Beleites
 Maintainer: Claudia Beleites <chemometrie@beleites.de>
+Authors@R: c(
+    person("Claudia", "Beleites", role = c("aut","cre"), email = "chemometrie@beleites.de"),
+    person("Valter", "Sergo", role = c("aut"))
+    )
 Description: Comfortable ways to work with hyperspectral data sets.
     I.e. spatially or time-resolved spectra, or spectra with any other kind
     of information associated with each of the spectra. The spectra can be data
@@ -45,6 +49,7 @@ Imports:
     utils,
     latticeExtra
 URL: http://hyperSpec.r-forge.r-project.org/
+BugReports: https://github.com/cbeleites/hyperSpec/issues
 Collate:
     'validate.R'
     'hyperspec-class.R'


### PR DESCRIPTION
"Authors@R" and "BugReports" fields added to DESCRIPTION file updated. 
1. "Authors@R" field is added for proper inclusion of all authors and contributors.
This field is a better alternative to  "Author" and "Maintainer" fields. Thus these two can be removed.
2. I think that other contributors should also be listed in "Authors@R" by adding role "ctb".
3. Is URL up to date as `hyperSpec` is now on `GitHub`?